### PR TITLE
Change mermaid output from svg (bug) to pdf

### DIFF
--- a/diagram.lua
+++ b/diagram.lua
@@ -116,13 +116,29 @@ end
 -- Mermaid
 --
 local function mermaid (code)
+  -- due to a bug (?) in mermaid (see https://github.com/mermaid-js/mermaid-cli/issues/112)
+  -- svg output have been switched to pdf output
+  -- -f flag has been added (only affects pdf output) to adapt the page size to the diagram.
+  -- mermaid bug does not affect all text : text in gitGraph is OK. But labels on graph are not.
+  -- test with the following code and see if integers are visible.
+  -- ```{.mermaid #fig:samtree01 caption="Sample Tree"}
+  -- graph TB;
+  -- A((10))-->B((3))
+  -- A-->C((12));
+  -- B-->E((1))
+  -- B-->F((7))
+  -- C-->H((11))
+  -- C-->I((4))
+  -- ```
   return with_temporary_directory("diagram", function (tmpdir)
     return with_working_directory(tmpdir, function ()
       local infile = 'diagram.mmd'
-      local outfile = 'diagram.svg'
+      -- local outfile = 'diagram.svg'
+      local outfile = 'diagram.pdf'
       write_file(infile, code)
-      pandoc.pipe(path['mmdc'], {'--input', infile, '--output', outfile}, '')
-      return read_file(outfile), 'image/svg+xml'
+      pandoc.pipe(path['mmdc'], {'-f', '--input', infile, '--output', outfile}, '')
+      -- return read_file(outfile), 'image/svg+xml'
+      return read_file(outfile), 'application/pdf'
     end)
   end)
 end

--- a/sample.md
+++ b/sample.md
@@ -270,6 +270,36 @@ label("$O$", O, W);
 label("$I$", I, E);
 ```
 
+## Mermaid
+[Mermaid](https://mermaid.js.org/#/) is a diagramming and charting tool.
+[mmdc](https://github.com/mermaid-js/mermaid-cli) is a cli to mermaid.
+Your distribution may have a package called `mermaid-cli` or `mmdc`.
+
+```{.mermaid caption="Sample git graph, created by **mermaid**."}
+gitGraph
+    commit
+    commit
+    branch develop
+    checkout develop
+    commit
+    commit
+    checkout main
+    merge develop
+    commit
+    commit
+```
+
+```{.mermaid #fig:samtree01 caption="Sample Tree"}
+graph TB;
+A((10))-->B((3))
+A-->C((12));
+B-->E((1))
+B-->F((7))
+C-->H((11))
+C-->I((4))
+```
+
+
 ## How to run pandoc
 This section will show, how to call Pandoc in order to use this filter with
 meta keys. The following command assume, that the filters are stored in the


### PR DESCRIPTION
Continuation of <https://github.com/pandoc/lua-filters/pull/266>
svg output does not work for graphs so the mermaid filter has been changed to produce pdf output instead.