### PR TITLE
Edit README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Currently supported options:
   Windows and `$HOME/.cache` on all other platforms.
 
   Caching is disabled if none of the environment variables
-  mentioned above has been defined.
+  mentioned above have been defined.
 
 - `engine`: options for specific engines, e.g. `plantuml` or
   `mermaid`. The options must be nested below the engine name.
@@ -114,7 +114,7 @@ Currently supported options:
 
   + `mime-type`: the output MIME type that should be produced with
     this engine. This can be used to choose a specific type, or to
-    disable certain output formats. For example, the below
+    disable certain output formats. For example, the following
     disables support for PDF output in PlantUML, which can be
     useful when the necessary libraries are unavailable on a
     system:


### PR DESCRIPTION
Is there a word missing on line [112](https://github.com/pandoc-ext/diagram/blob/3e374b8617e8883f664b95db42929a3ff6416b2a/README.md?plain=1#L112)? It reads "respectively, or a a map of options."