### PR TITLE
allow SVG for any document format but keep high priority in non-PDF

### DIFF
--- a/_extensions/diagram/diagram.lua
+++ b/_extensions/diagram/diagram.lua
@@ -241,6 +241,8 @@ local function format_options (name)
   -- Prefer SVG for non-PDF output formats
   if pdf2svg then
     preferred_mime_types:insert(1, 'image/svg+xml')
+  else
+    preferred_mime_types:insert('image/svg+xml')
   end
   return {
     name = name,


### PR DESCRIPTION
Right now SVG (image/svg+xml) cannot be selected as a valid format for a diagram if the document output format is latex/context (so PDF as well).

As pandoc can convert SVG into some compatible format using `rsvg-convert`, This allows the SVG format to be in the `preferred_mime_types` list.

The previous behavior with non-PDF output formats is kept as is (raising the SVG format priority in the `preferred_mime_types` list).