### PR TITLE
issue #15 use standalone [tikz] option instead of \usepackage{tikz}

### DIFF
--- a/_extensions/diagram/diagram.lua
+++ b/_extensions/diagram/diagram.lua
@@ -148,8 +148,7 @@ local mermaid = {
 --- packages as the first, and the actual TikZ code as the second
 --- argument.
 local tikz_template = pandoc.template.compile [[
-\documentclass{standalone}
-\usepackage{tikz}
+\documentclass[tikz]{standalone}
 $for(header-includes)$
 $it$
 $endfor$


### PR DESCRIPTION
fix for left-hand border of tikz diagrams