### PR TITLE
warn function throws error

### DIFF
--- a/_extensions/diagram/diagram.lua
+++ b/_extensions/diagram/diagram.lua
@@ -10,7 +10,7 @@ PANDOC_VERSION:must_be_at_least '3.0'
 if warn then
   warn '@on'
 else
-  warn = function (...) io.stderr:write(string.concat({...})) end
+  warn = function(...) io.stderr:write(table.concat({ ... })) end
 end
 
 local system = require 'pandoc.system'


### PR DESCRIPTION

the warn function uses `string.concat` which does not appear to be real. did we mean `table.concat`?


Sorry I accidentally deleted this branch and closed the previous pull request. It's back now.