### PR TITLE
README: add missing `diagram` key in `diagram-filter.yaml`

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,21 +255,22 @@ that the configs cannot be overwritten by the document.
 # file: diagram-filter.yaml
 filters: ['diagram.lua']
 metadata:
-  engine:
-    # enable dot/GraphViz and PlantUML with default options
-    dot: true
-    plantuml: true
+  diagram:
+    engine:
+      # enable dot/GraphViz and PlantUML with default options
+      dot: true
+      plantuml: true
 
-    # disable processing of asymptote and Mermaid diagrams
-    asymptote: false
-    mermaid: false
+      # disable processing of asymptote and Mermaid diagrams
+      asymptote: false
+      mermaid: false
 
-    # Use LuaLaTeX to compile TikZ, define headers
-    tikz:
-      execpath: lualatex
-      additional-packages: |
-        \usepackage{adjustbox}
-        \usetikzlibrary{arrows, shapes}
+      # Use LuaLaTeX to compile TikZ, define headers
+      tikz:
+        execpath: lualatex
+        additional-packages: |
+          \usepackage{adjustbox}
+          \usetikzlibrary{arrows, shapes}
 ```
 
 Usage:


### PR DESCRIPTION
This was the first time I've used `pandoc -d` and it took me a while to figure out that the `README.md` `diagram-filter.yaml` example was missing the parent `diagram` metadata key, even though it is mentioned in the text. :sweat_smile: 