### PR TITLE
Add ability to convert text to paths through inkscape

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,28 @@ diagram:
 ---
 ```
 
+When converting to non-LaTeX formats, the Ti*k*Z engine uses `inkscape` to convert images to SVG. By default, these SVG files reference fonts by name, which means that text will only render correctly if those fonts are installed in the viewer. This can lead to inconsistent output in formats like HTML and docx.
+
+One option is to convert SVG text to vector outlines (paths), which ensures consistent appearance across viewers (but at the cost of making text unselectable and unsearchable in the diagram).
+
+To enable this, set `text-to-path: true` in the `pdf2svg` option for the tikz engine (this is `false` by default).
+
+Example:
+
+``` yaml
+---
+diagram:
+  engine:
+    tikz:
+      execpath: lualatex
+      pdf2svg:
+        text-to-path: true
+      header-includes:
+        - '\usepackage{adjustbox}'
+        - '\usetikzlibrary{arrows, shapes}'
+---
+```
+
 Security
 --------
 

--- a/_extensions/diagram/diagram.lua
+++ b/_extensions/diagram/diagram.lua
@@ -448,7 +448,8 @@ end
 --
 
 --- Converts a PDF to SVG.
-local pdf2svg = function (imgdata)
+local pdf2svg = function (imgdata, opts)
+  opts = opts or {}
   -- Using `os.tmpname()` instead of a hash would be slightly cleaner, but the
   -- function causes problems on Windows (and wasm). See, e.g.,
   -- https://github.com/pandoc-ext/diagram/issues/49
@@ -460,6 +461,9 @@ local pdf2svg = function (imgdata)
     '--export-filename=-',
     pdf_file
   }
+  if opts['text-to-path'] then
+    table.insert(args, 3, '--export-text-to-path')
+  end
   return pandoc.pipe('inkscape', args, ''), os.remove(pdf_file)
 end
 
@@ -612,7 +616,7 @@ local function code_to_figure (conf)
 
       -- Convert SVG if necessary.
       if imgtype == 'application/pdf' and conf.format.pdf2svg then
-        imgdata, imgtype = pdf2svg(imgdata), 'image/svg+xml'
+        imgdata, imgtype = pdf2svg(imgdata, engine.opt['pdf2svg']), 'image/svg+xml'
       end
 
       -- If we got here, then the transformation went ok and `img` contains


### PR DESCRIPTION
When converting to non-LaTeX formats, the Ti*k*Z engine uses `inkscape` to convert images to SVG. By default, these SVG files reference fonts by name, which means that text will only render correctly if those fonts are installed in the viewer.

For instance, this chunk:

````
```{.tikz caption="Simple graph." filename="graph"}
\begin{tikzpicture}
  \node (a) at (0,0) {$A$};
  \node (b) at (2,0) {$B$};
  \draw[->] (a) -- (b);
\end{tikzpicture}
```
````

creates `graph.svg` with font styles embedded in it:

```svg
<g
   id="g22"
   transform="translate(-3.321,-3.321)">
  <text
     xml:space="preserve"
     transform="matrix(1,0,0,-1,3.321,3.321)"
     style="font-variant:normal;font-weight:normal;font-size:9.9626px;font-family:CMMI10;-inkscape-font-specification:CMMI10;writing-mode:lr-tb;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
     id="text26"><tspan
       x="0"
       y="0"
       id="tspan24">A</tspan></text>
  <g
     id="g28"
     transform="translate(3.321,3.321)" />
</g>
```

When viewed in HTML or docx, this will not appear correctly unless "CMMI10" is installed as a font.

One option is to convert SVG text to vector outlines (paths), which ensures consistent appearance across viewers (but at the cost of making text unselectable and unsearchable in the diagram).

This PR adds an optional setting at `diagram: engine: tikz: pdf2svg: text-to-path` (default false) to tell Inkscape to convert the diagram text to outlines/paths

With this YAML:

````yaml
diagram:
  engine:
    tikz:
      pdf2svg:
        text-to-path: true
````

…this chunk:

````
```{.tikz caption="Simple graph." filename="graph"}
\begin{tikzpicture}
  \node (a) at (0,0) {$A$};
  \node (b) at (2,0) {$B$};
  \draw[->] (a) -- (b);
\end{tikzpicture}
```
````

creates `graph.svg` with letters embedded as shapes/paths:

```svg
<g
  aria-label="A"
  transform="matrix(1,0,0,-1,3.321,3.321)"
  id="text26"
  style="font-size:9.9626px;font-family:CMMI10;-inkscape-font-specification:CMMI10">
    <path
    d="M 5.4288385,0 4.5726776,-2.2036414 H 1.7512382 L 0.90480642,0 H 0 L 2.7776584,-7.1411604 H 3.5851738 L 6.3579677,0 Z M 4.3051273,-2.9965632 3.507341,-5.1515592 3.1668225,-6.2168957 q -0.1459365,0.583746 -0.3064667,1.0653365 l -0.8075154,2.154996 z"
    id="path56" />
</g>
```

---

For the sake of simplicity, I just used `table.insert()` to stick the `--export-text-to-path` flag into the existing arguments in `pdf2svg()`:

```lua
local args = {
  '--export-type=svg',
  '--export-plain-svg',
  '--export-filename=-',
  pdf_file
}
if opts['text-to-path'] then
  table.insert(args, 3, '--export-text-to-path')
end
```

…but it could be fancier/more robust, especially if something like #64 is implemented (though this is *slightly* different since this isn't a per-chunk setting, but it could be, I guess)

---

There are no tests because the current tests only check that the svg is linked in the test HTML output, but doesn't inspect the content of the SVG (though I suppose it would be possible to use `embed-resources` and check against the base64 embedded SVG)